### PR TITLE
feat: Allows use of ** in spec patterns to match recursive directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
       upload_to_bucket: false
       fail_on_lint_error: true
 
+  test-lint-file-globstar-ok:
+    uses: ./.github/workflows/lint.yml
+    with:
+      spec: fixture/**/openapi-good-*.yaml
+      upload_to_bucket: false
+      fail_on_lint_error: true
+
   upload-artifact:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,8 @@ jobs:
         run: npm install -g @stoplight/spectral-cli
       - name: Lint OpenAPI
         run: |
+          shopt -s globstar
+
           if [ -n "${{ inputs.artifact }}" ]; then
             spec_glob="/tmp/artifacts/${{ inputs.artifact_contents }}"
           else
@@ -117,6 +119,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
       - name: Copy specs to temporary directory
         run: |
+          shopt -s globstar
+
           mkdir -p /tmp/specs
 
           if [ -z "${{ inputs.artifact }}" ]; then            

--- a/fixture/nested/openapi-good-link.yaml
+++ b/fixture/nested/openapi-good-link.yaml
@@ -1,0 +1,1 @@
+../openapi-good.yaml


### PR DESCRIPTION
Enables Bash globstar pattern to allow for use of `**` in spec patterns.

Our apps have specs that are sometimes located in `src/main/resources/openapi/<app>.json` and sometimes in `backend/src/main/resources/openapi/<app>.json`. With this PR we can catch all of these locations with one pattern: `**/src/main/resources/openapi/<app>.json`.

I am unsure of the exact workings of your CI test workflow, I did my best :)