### PR TITLE
fix: Remove conditions for running publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   validate-input:
     name: Validate input
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Validate inputs
@@ -55,12 +54,6 @@ jobs:
 
   upload-to-bucket:
     name: Upload to bucket
-    if: |
-      (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) ||
-      (github.event_name == 'pull_request' && 
-       github.event.action == 'closed' && 
-       github.event.pull_request.merged == true && 
-       github.event.pull_request.base.ref == github.event.repository.default_branch)
     needs: validate-input
     permissions:
       contents: read


### PR DESCRIPTION
Leave it up to the calling workflow to decide whether or not it should be run. There might be different requirements for different apps running the workflow.