### PR TITLE
fix: use generic updater type for workflow extra-files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,18 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "extra-files": [
-    ".github/workflows/lint.yml",
-    ".github/workflows/publish.yml",
-    ".github/workflows/validate.yml"
+    {
+      "type": "generic",
+      "path": ".github/workflows/lint.yml"
+    },
+    {
+      "type": "generic",
+      "path": ".github/workflows/publish.yml"
+    },
+    {
+      "type": "generic",
+      "path": ".github/workflows/validate.yml"
+    }
   ],
   "packages": {
     ".": {}


### PR DESCRIPTION
Fixes the `create release` workflow failing after every merge. The YAML updater was looking for `$.version` in the workflow files (not found), causing release-please to fail when building the tree. `type: generic` uses the `x-release-please-version` comment annotation instead.

BEGIN_COMMIT_OVERRIDE
chore: use generic updater
END_COMMIT_OVERRIDE