### PR TITLE
fix(ETU-73873): Override spectral-rulesets version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,9 @@ on:
 
 
 env:
-  REDOCLY_VERSION: "2.30.6"
-  SPECTRAL_VERSION: "6.16.0"
+  REDOCLY: npx --ignore-scripts @redocly/cli@2.30.6
+  # Need to force spectral-rulesets version to work around https://github.com/stoplightio/spectral/issues/2959
+  SPECTRAL: npx --ignore-scripts -p @stoplight/spectral-cli@6.16.0 -p @stoplight/spectral-rulesets@1.22.2 spectral
   NPM_CONFIG_IGNORE_SCRIPTS: true
   NPM_CONFIG_MIN_RELEASE_AGE: 4
 
@@ -143,7 +144,7 @@ jobs:
           annotations=$(mktemp)
           markdown=$(mktemp)
           #Capture return code in $rc, and do not fail workflow.
-          npx --ignore-scripts @stoplight/spectral-cli@$SPECTRAL_VERSION lint "$GHA_API_PATH" --ruleset "rulesets/.spectral.yml" --show-documentation-url -F hint -f github-actions -o.github-actions "$annotations" -f markdown -o.markdown="$markdown" && rc=$? || rc=$?
+          $SPECTRAL lint "$GHA_API_PATH" --ruleset "rulesets/.spectral.yml" --show-documentation-url -F hint -f github-actions -o.github-actions "$annotations" -f markdown -o.markdown="$markdown" && rc=$? || rc=$?
           
           #Return code 2 means that spectral command failed to run (not linting errors), so fail workflow.
           if [ "$rc" -eq 2 ]; then
@@ -167,7 +168,7 @@ jobs:
             echo
 
             if [ "$GHA_API_FAIL_THRESHOLD" != "never" ]; then
-              npx --ignore-scripts @stoplight/spectral-cli@$SPECTRAL_VERSION lint "$GHA_API_PATH" --ruleset "rulesets/.spectral.yml" -o "/dev/null" -f json -F "$GHA_API_FAIL_THRESHOLD" && rc=$? || rc=$?
+              $SPECTRAL lint "$GHA_API_PATH" --ruleset "rulesets/.spectral.yml" -o "/dev/null" -f json -F "$GHA_API_FAIL_THRESHOLD" && rc=$? || rc=$?
 
               if [ "$rc" -ne 0 ]; then
                 echo "::error::Found linting problems. Failing workflow."
@@ -210,7 +211,7 @@ jobs:
 
           filename=$(basename $GHA_API_PATH)
           mkdir -p /tmp/specs
-          npx @redocly/cli@$REDOCLY_VERSION bundle -o /tmp/specs/$filename $GHA_API_PATH
+          $REDOCLY bundle -o /tmp/specs/$filename $GHA_API_PATH
 
           cp $GHA_API_PATH /tmp/specs
       - name: Upload specs to GCS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,9 @@ on:
         type: string
 
 env:
-  REDOCLY_VERSION: "2.30.6"
-  SPECTRAL_VERSION: "6.16.0"
+  REDOCLY: npx --ignore-scripts @redocly/cli@2.30.6
+  # Need to force spectral-rulesets version to work around https://github.com/stoplightio/spectral/issues/2959
+  SPECTRAL: npx --ignore-scripts -p @stoplight/spectral-cli@6.16.0 -p @stoplight/spectral-rulesets@1.22.2 spectral
   NPM_CONFIG_IGNORE_SCRIPTS: true
   NPM_CONFIG_MIN_RELEASE_AGE: 4
 
@@ -86,12 +87,12 @@ jobs:
           set -o pipefail          
           shopt -s globstar
 
-          if ! npx @stoplight/spectral-cli@$SPECTRAL_VERSION lint "$GHA_API_PATH" --ruleset "rulesets/.spectral-required.yml"; then
+          if ! $SPECTRAL lint "$GHA_API_PATH" --ruleset "rulesets/.spectral-required.yml"; then
             echo "::error::Spec validation failed. Failing workflow."
             exit 1
           fi  
 
-          if ! npx @redocly/cli@$REDOCLY_VERSION bundle $GHA_API_PATH; then
+          if ! $REDOCLY bundle $GHA_API_PATH; then
             echo "::error::Spec bundling failed. Failing workflow."
             exit 1
           fi  
@@ -118,7 +119,7 @@ jobs:
 
           filename=$(basename $GHA_API_PATH)
           mkdir -p /tmp/specs
-          npx @redocly/cli@$REDOCLY_VERSION bundle -o /tmp/specs/$filename $GHA_API_PATH
+          $REDOCLY bundle -o /tmp/specs/$filename $GHA_API_PATH
 
           # Extract repository name (without owner)
           REPO_NAME="${GITHUB_REPOSITORY#*/}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,8 +11,9 @@ on:
         type: string
 
 env:
-  REDOCLY_VERSION: "2.30.6"
-  SPECTRAL_VERSION: "6.16.0"
+  REDOCLY: npx --ignore-scripts @redocly/cli@2.30.6
+  # Need to force spectral-rulesets version to work around https://github.com/stoplightio/spectral/issues/2959
+  SPECTRAL: npx --ignore-scripts -p @stoplight/spectral-cli@6.16.0 -p @stoplight/spectral-rulesets@1.22.2 spectral
   NPM_CONFIG_IGNORE_SCRIPTS: true
   NPM_CONFIG_MIN_RELEASE_AGE: 4
 
@@ -102,7 +103,7 @@ jobs:
           echo "Validating spec: $GHA_API_PATH"
 
           echo "Linting with minimal ruleset..."
-          if ! npx --ignore-scripts @stoplight/spectral-cli@$SPECTRAL_VERSION lint "$GHA_API_PATH" --ruleset "rulesets/.spectral-required.yml"; then
+          if ! $SPECTRAL lint "$GHA_API_PATH" --ruleset "rulesets/.spectral-required.yml"; then
             echo "::error::Spec validation failed. Failing workflow."
             exit 1
           fi
@@ -110,7 +111,7 @@ jobs:
           echo "Bundling..."
           filename=$(basename $GHA_API_PATH)
           mkdir -p /tmp/specs
-          npx --ignore-scripts @redocly/cli@$REDOCLY_VERSION bundle -o /tmp/specs/$filename $GHA_API_PATH
+          $REDOCLY bundle -o /tmp/specs/$filename $GHA_API_PATH
 
           # Extract repository name (without owner)
           REPO_NAME="${GITHUB_REPOSITORY#*/}"

--- a/fixture/openapi-good.json
+++ b/fixture/openapi-good.json
@@ -69,10 +69,13 @@
             "example": "Item 100"
           }
         },
-        "example": {
+        "examples": [{
           "id": "100",
           "name": "Item 100"
-        }
+        }, {
+          "id": "100",
+          "name": null
+        }]
       },
       "Items": {
         "type": "array",


### PR DESCRIPTION
See this issue: https://github.com/stoplightio/spectral/issues/2959

Tl;Dr; A bad PR was merged and released in `@stoplight/spectral-rulesets` version 1.22.3. Luckily we can override the version to 1.22.2.