### PR TITLE
fix: Use new syntax for referencing action in same repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,14 +118,10 @@ jobs:
           sparse-checkout: |
             .spectral*.yml
             functions/*.js
-      - uses: jenseng/dynamic-uses@8bc24f0360175e710da532c4d19eafdbed489a06 #v1.1.1
+      - uses: $/.github/actions/setup-spectral
         name: Setup spectral
-        with:
-          uses: ${{ job.workflow_repository }}/.github/actions/setup-spectral@${{ job.workflow_sha }}
-      - uses: jenseng/dynamic-uses@8bc24f0360175e710da532c4d19eafdbed489a06 #v1.1.1
+      - uses: $/.github/actions/setup-redocly
         name: Setup redocly
-        with:
-          uses: ${{ job.workflow_repository }}/.github/actions/setup-redocly@${{ job.workflow_sha }}
       - name: Lint OpenAPI
         shell: bash
         env:


### PR DESCRIPTION
Github just announced a better syntax for referencing an action/workflow that lives in the same workflow: https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/ So now we don't have to rely on a third party action anymore :tada:

Verified to work here: https://github.com/entur/api-spec-registry/actions/runs/30635394537/job/91171593482?pr=188