### PR TITLE
chore: Only update docs if prs_created

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
     uses: entur/gha-meta/.github/workflows/release.yml@v1
   update-docs:
     needs: release
-    if: needs.release.outputs.releases_created == 'false'
+    if: needs.release.outputs.releases_created == 'false' && needs.release.outputs.prs_created == 'true'
     strategy:
       max-parallel: 1 # Can't have them commit in parallel
       matrix:


### PR DESCRIPTION
Otherwise, it will fail anyways, since the branch in which it tries to update the documentation does not exist. And because there can't be any changes to document, since if there were, there would be a PR.

See failing workflow: https://github.com/entur/gha-api/actions/runs/30635236914/job/91171099720

and PR in gha-meta which added the output: https://github.com/entur/gha-meta/pull/117